### PR TITLE
Make structs to simplify loading and writing VSCode files

### DIFF
--- a/vscodeconfigurator/src/vscode_ops/csharp.rs
+++ b/vscodeconfigurator/src/vscode_ops/csharp.rs
@@ -2,7 +2,11 @@ use std::{fs, path::PathBuf};
 
 use serde_json::{json, Value};
 
-use crate::{console_utils::ConsoleUtils, subcommands::csharp::init::CsharpLspOption};
+use crate::{
+    console_utils::ConsoleUtils,
+    subcommands::csharp::init::CsharpLspOption,
+    vscode_ops::VSCodeSettings
+};
 
 /// Updates the C# LSP option in the `.vscode/settings.json` file.
 /// 
@@ -16,26 +20,21 @@ pub fn update_csharp_lsp(
     csharp_lsp: CsharpLspOption,
     console_utils: &mut ConsoleUtils
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let vscode_settings_path = output_directory.join(".vscode/settings.json");
-
     console_utils.write_info(format!("- 📄 Updating C# LSP option in tasks.json... "))?;
 
-    let vscode_settings_json = fs::read_to_string(&vscode_settings_path)?;
+    let mut vscode_settings = VSCodeSettings::new(output_directory.join(".vscode/settings.json"));
 
-    let mut vscode_settings: Value = serde_json::from_str(&vscode_settings_json.as_str())?;
-
-    vscode_settings["dotnet.server.useOmnisharp"] = match csharp_lsp {
+    vscode_settings.values["dotnet.server.useOmnisharp"] = match csharp_lsp {
         CsharpLspOption::CsharpLsp => Value::Bool(false),
         CsharpLspOption::OmniSharp => Value::Bool(true)
     };
 
-    vscode_settings["dotnet.server.path"] = match csharp_lsp {
+    vscode_settings.values["dotnet.server.path"] = match csharp_lsp {
         CsharpLspOption::CsharpLsp => Value::String("".to_string()),
         CsharpLspOption::OmniSharp => Value::String("latest".to_string())
     };
 
-    let updated_vscode_settings_json = serde_json::to_string_pretty(&vscode_settings)?;
-    fs::write(&vscode_settings_path, updated_vscode_settings_json)?;
+    vscode_settings.write_settings()?;
 
     console_utils.write_success(format!("Done! ✅\n"))?;
 

--- a/vscodeconfigurator/src/vscode_ops/csharp.rs
+++ b/vscodeconfigurator/src/vscode_ops/csharp.rs
@@ -1,11 +1,11 @@
-use std::{fs, path::PathBuf};
+use std::path::PathBuf;
 
 use serde_json::{json, Value};
 
 use crate::{
     console_utils::ConsoleUtils,
     subcommands::csharp::init::CsharpLspOption,
-    vscode_ops::VSCodeSettings
+    vscode_ops::{VSCodeSettings, VSCodeTasks}
 };
 
 /// Updates the C# LSP option in the `.vscode/settings.json` file.
@@ -59,15 +59,11 @@ pub fn add_csharp_project_to_tasks(
     is_watchable: bool,
     console_utils: &mut ConsoleUtils
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let vscode_tasks_path = output_directory.join(".vscode/tasks.json");
-
     console_utils.write_info(format!("- 📄 Adding C# project to tasks.json... "))?;
 
-    let vscode_tasks_json = fs::read_to_string(&vscode_tasks_path)?;
+    let mut vscode_tasks = VSCodeTasks::new(output_directory.join(".vscode/tasks.json"));
 
-    let mut vscode_tasks: Value = serde_json::from_str(&vscode_tasks_json.as_str())?;
-
-    let inputs_node = vscode_tasks["inputs"].as_array_mut().unwrap();
+    let inputs_node = vscode_tasks.values["inputs"].as_array_mut().unwrap();
 
     let csharp_project_input = json!({
         "label": project_friendly_name,
@@ -94,8 +90,7 @@ pub fn add_csharp_project_to_tasks(
         }
     }
 
-    let updated_vscode_tasks_json = serde_json::to_string_pretty(&vscode_tasks)?;
-    fs::write(&vscode_tasks_path, updated_vscode_tasks_json)?;
+    vscode_tasks.write_tasks()?;
 
     console_utils.write_success(format!("Done! ✅\n"))?;
 

--- a/vscodeconfigurator/src/vscode_ops/mod.rs
+++ b/vscodeconfigurator/src/vscode_ops/mod.rs
@@ -46,3 +46,44 @@ impl VSCodeSettings {
         Ok(())
     }
 }
+
+/// Represents the tasks file for a Visual Studio Code workspace.
+pub struct VSCodeTasks {
+    /// The path to the tasks file.
+    pub file_path: PathBuf,
+
+    /// The values in the tasks file.
+    pub values: Value
+}
+
+impl VSCodeTasks {
+    /// Creates a new `VSCodeTasks` instance.
+    /// 
+    /// ## Arguments
+    /// 
+    /// * `file_path` - The path to the tasks file.
+    pub fn new(
+        file_path: PathBuf
+    ) -> Self {
+        if !file_path.exists() {
+            panic!("The tasks file does not exist.");
+        }
+
+        let tasks_json = fs::read_to_string(&file_path).unwrap();
+        let tasks = serde_json::from_str(&tasks_json.as_str()).unwrap();
+
+        Self {
+            file_path: file_path,
+            values: tasks
+        }
+    }
+
+    /// Writes the tasks to the tasks file.
+    pub fn write_tasks(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let updated_tasks_json = serde_json::to_string_pretty(&self.values)?;
+
+        fs::write(&self.file_path, updated_tasks_json)?;
+
+        Ok(())
+    }
+}

--- a/vscodeconfigurator/src/vscode_ops/mod.rs
+++ b/vscodeconfigurator/src/vscode_ops/mod.rs
@@ -1,1 +1,48 @@
 pub mod csharp;
+
+use std::{fs, path::PathBuf};
+
+use serde_json::Value;
+
+/// Represents the settings file for a Visual Studio Code workspace.
+/// 
+/// ## Fields
+/// 
+/// * `file_path` - The path to the settings file.
+/// * `values` - The values in the settings file.
+pub struct VSCodeSettings {
+    pub file_path: PathBuf,
+    pub values: Value
+}
+
+impl VSCodeSettings {
+    /// Creates a new `VSCodeSettings` instance.
+    /// 
+    /// ## Arguments
+    /// 
+    /// * `file_path` - The path to the settings file.
+    pub fn new(
+        file_path: PathBuf
+    ) -> Self {
+        if !file_path.exists() {
+            panic!("The settings file does not exist.");
+        }
+
+        let settings_json = fs::read_to_string(&file_path).unwrap();
+        let settings = serde_json::from_str(&settings_json.as_str()).unwrap();
+
+        Self {
+            file_path: file_path,
+            values: settings
+        }
+    }
+
+    /// Writes the settings to the settings file.
+    pub fn write_settings(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let updated_settings_json = serde_json::to_string_pretty(&self.values)?;
+
+        fs::write(&self.file_path, updated_settings_json)?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Description

* Adds two structs (`VSCodeSettings` and `VSCodeTasks`) to simplify how the `settings.json` and `tasks.json` files in a VSCode workspace are interacted with.

### Related issues

- None
