### PR TITLE
Improve how the package version is updated locally

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -44,10 +44,7 @@
                 "${input:packageName}"
             ],
             "options": {
-                "cwd": "${workspaceFolder}",
-                "env": {
-                    "VSCODECONFIGURATOR_UPDATE_MANIFEST_VERSION": "${input:updateManifestVersion}"
-                }
+                "cwd": "${workspaceFolder}"
             },
             "presentation": {
                 "echo": true,
@@ -193,6 +190,39 @@
 				"clear": true,
 			},
 			"problemMatcher": []
+		},
+        {
+			"label": "Update package version",
+			"detail": "Update the version for a package in the workspace.",
+			"icon": {
+				"id": "versions",
+				"color": "terminal.ansiBlack"
+			},
+			"type": "process",
+			"command": "pwsh",
+			"args": [
+				"-NoLogo",
+				"-NoProfile",
+				"-File",
+				"${workspaceFolder}/tools/Update-PackageVersion.ps1",
+				"-PackageName",
+				"${input:packageName}",
+                "-CustomVersion",
+                "${input:newPackageVersion}",
+				"-Verbose"
+			],
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"presentation": {
+				"echo": true,
+				"reveal": "always",
+				"focus": true,
+				"panel": "shared",
+				"showReuseMessage": true,
+				"clear": true,
+			},
+			"problemMatcher": []
 		}
     ],
     "inputs": [
@@ -230,20 +260,10 @@
             ]
         },
         {
-            "id": "updateManifestVersion",
-            "description": "Should the manifest version be updated?",
-            "type": "pickString",
-            "default": "No",
-            "options": [
-                {
-                    "label": "Yes",
-                    "value": "true"
-                },
-                {
-                    "label": "No",
-                    "value": "false"
-                }
-            ]
+            "id": "newPackageVersion",
+            "description": "Enter the new version for the package",
+            "type": "promptString",
+            "default": ""
         }
     ]
 }

--- a/tools/Update-PackageVersion.ps1
+++ b/tools/Update-PackageVersion.ps1
@@ -1,0 +1,82 @@
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [Parameter(Position = 0)]
+    [string]$RootDirectory = (Get-Location).Path,
+    [Parameter(Position = 1, Mandatory)]
+    [ValidateSet(
+        "vscodeconfigurator"
+    )]
+    [string]$PackageName = "vscodeconfigurator",
+    [Parameter(Position = 2)]
+    [string]$CustomVersion
+)
+
+$resolvedRootDirectory = (Resolve-Path -Path $RootDirectory -ErrorAction "Stop").Path
+
+if ([System.IO.FileAttributes]::Directory -notin (Get-Item -Path $resolvedRootDirectory).Attributes) {
+    $PSCmdlet.ThrowTerminatingError(
+        [System.Management.Automation.ErrorRecord]::new(
+            [System.Exception]::new("The specified root directory is not a directory."),
+            "RootDirectoryIsNotDirectory",
+            [System.Management.Automation.ErrorCategory]::InvalidArgument,
+            $resolvedRootDirectory
+        )
+    )
+}
+
+$newPackageVersion = $null
+switch ([string]::IsNullOrWhiteSpace($CustomVersion)) {
+    $true {
+        $gitDescribeProcInfo = [System.Diagnostics.ProcessStartInfo]::new(
+            "git",
+            @(
+                "describe",
+                "--tags",
+                "--abbrev=0"
+            )
+        )
+
+        $gitDescribeProcInfo.WorkingDirectory = $resolvedRootDirectory
+        $gitDescribeProcInfo.RedirectStandardOutput = $true
+
+        $gitDescribeProc = [System.Diagnostics.Process]::Start($gitDescribeProcInfo)
+        $gitDescribeProc.WaitForExit()
+
+        $gitDescribeProcStandardOutput = $gitDescribeProc.StandardOutput.ReadToEnd()
+        $gitDescribeProcStandardOutput = $gitDescribeProcStandardOutput.Trim()
+
+        $newPackageVersion = $gitDescribeProcStandardOutput
+        break
+    }
+
+    $false {
+        $newPackageVersion = $CustomVersion
+        break
+    }
+}
+
+$newPackageVersionTrimmed = $newPackageVersion.TrimStart("v")
+
+$packageDirectory = Join-Path -Path $resolvedRootDirectory -ChildPath $PackageName
+$packageManifestPath = Join-Path -Path $packageDirectory -ChildPath "Cargo.toml"
+
+$manifestVersionRegex = [regex]::new("^version = \`"(?'version'.+?)\`"`$", [System.Text.RegularExpressions.RegexOptions]::Multiline)
+
+$packageManifestContent = Get-Content -Path $packageManifestPath -Raw
+
+$manifestVersionMatch = $manifestVersionRegex.Match($packageManifestContent)
+
+if (!$manifestVersionMatch.Success) {
+    $PSCmdlet.ThrowTerminatingError(
+        [System.Management.Automation.ErrorRecord]::new(
+            [System.Exception]::new("Failed to extract the current package version from the manifest."),
+            "FailedToExtractPackageVersion",
+            [System.Management.Automation.ErrorCategory]::InvalidData,
+            $packageManifestPath
+        )
+    )
+}
+
+if ($PSCmdlet.ShouldProcess($PackageName, "Update version to $($newPackageVersion)")) {
+    $manifestVersionRegex.Replace($packageManifestContent, "version = `"$($newPackageVersionTrimmed)`"") | Out-File -FilePath $packageManifestPath -Encoding "UTF8" -NoNewline -Force
+}


### PR DESCRIPTION
## Description

* Add a script for manually updating the version for a specific package manifest.
* Add a VSCode task to run the script.
* Removes the package manifest being updated when running the **Build package (Release)** task.

### Related issues

- None
