### PR TITLE
Remove extra newline in 'git init' message

### DIFF
--- a/vscodeconfigurator/src/external_procs/git.rs
+++ b/vscodeconfigurator/src/external_procs/git.rs
@@ -12,7 +12,7 @@ pub fn initialize_git_repo(
     output_directory: &PathBuf,
     console_utils: &mut ConsoleUtils
 ) -> Result<(), Box<dyn std::error::Error>> {
-    console_utils.write_info(format!("\n- 📦 Initializing Git repository... "))?;
+    console_utils.write_info(format!("- 📦 Initializing Git repository... "))?;
     
     let git_proc_args = vec![
         "init"


### PR DESCRIPTION
## Description

* Removes an extra newline in the `git init` log message.

### Related issues

- None
