### PR TITLE
Add OutputDirectory struct

### DIFF
--- a/vscodeconfigurator/src/io.rs
+++ b/vscodeconfigurator/src/io.rs
@@ -1,0 +1,125 @@
+use std::{env, ffi::OsString, fmt, io, path::{absolute, Path, PathBuf}};
+
+use crate::error::{CliError, CliErrorKind};
+
+/// Represents an output directory.
+#[derive(Clone, Debug, PartialEq)]
+pub struct OutputDirectory {
+    pub path: String
+}
+
+impl OutputDirectory {
+    /// Creates a new `OutputDirectory` from the current directory.
+    pub fn from_current_dir() -> Self {
+        let current_dir = env::current_dir().unwrap().into_os_string();
+
+        Self {
+            path: current_dir
+                .to_string_lossy()
+                .to_string()
+        }
+    }
+
+    /// Creates a new `OutputDirectory` from an `OsString`.
+    /// 
+    /// ### Arguments
+    /// 
+    /// * `path` - The path to create the `OutputDirectory` from.
+    pub fn from_os_string(path: OsString) -> Result<Self, io::Error> {
+        let input_path = PathBuf::from(&path)
+            .canonicalize();
+
+        let input_path_string = match input_path.is_err() {
+            true => {
+                absolute(PathBuf::from(&path))
+                    .unwrap()
+                    .to_string_lossy()
+                    .to_string()
+            }
+
+            false => {
+                input_path
+                    .unwrap()
+                    .to_string_lossy()
+                    .to_string()
+            }
+        };
+
+        Ok(
+            Self {
+                path: input_path_string
+            }
+        )
+    }
+
+    /// Converts the `OutputDirectory` to a `PathBuf`.
+    pub fn as_pathbuf(&self) -> PathBuf {
+        PathBuf::from(&self.path)
+    }
+
+    /// Resolves the home directory in the path if it starts with `~`.
+    pub fn resolve_home_dir(&mut self) -> Result<OutputDirectory, CliError> {
+        if self.path.starts_with("~") {
+            let home_dir_env_var_key = match env::consts::OS {
+                "windows" => "USERPROFILE",
+                "unix" | "macos" => "HOME",
+                _ => return Err(CliError::new("The operating system is not supported.", CliErrorKind::UnsupportedOperatingSystem).into()),
+            };
+            let home_dir_env_var = env::var(home_dir_env_var_key).unwrap();
+            let home_dir = Path::new(&home_dir_env_var);
+
+            self.path =
+                PathBuf::from(&home_dir)
+                    .join(self.path
+                        .strip_prefix("~")
+                        .unwrap()
+                    )
+                    .to_string_lossy()
+                    .to_string();
+        }
+
+        Ok(self.clone())
+    }
+
+    /// Trims trailing slashes from the path.
+    pub fn trim_trailing_slashes(&mut self) -> Result<OutputDirectory, CliError> {
+        self.path = self.path
+            .trim_end_matches('/')
+            .trim_end_matches('.')
+            .to_string();
+
+        Ok(self.clone())
+    }
+
+    /// Creates the directory if it does not exist.
+    pub fn create_if_not_exists(&self) -> Result<(), io::Error> {
+        if !Path::new(&self.path).exists() {
+            std::fs::create_dir(&self.path)?;
+        }
+
+        Ok(())
+    }
+
+    /// Converts the path to an absolute path.
+    pub fn to_absolute(&self) -> PathBuf {
+        return absolute(self.as_pathbuf()).unwrap();
+    }
+}
+
+impl fmt::Display for OutputDirectory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.path)
+    }
+}
+
+impl Into<clap::builder::OsStr> for OutputDirectory {
+    fn into(self) -> clap::builder::OsStr {
+        self.path.into()
+    }
+}
+
+impl Into<PathBuf> for OutputDirectory {
+    fn into(self) -> PathBuf {
+        PathBuf::from(self.path)
+    }
+}

--- a/vscodeconfigurator/src/main.rs
+++ b/vscodeconfigurator/src/main.rs
@@ -5,6 +5,7 @@ mod template_ops;
 mod vscode_ops;
 mod utils;
 mod error;
+mod io;
 
 use std::{error::Error, process};
 

--- a/vscodeconfigurator/src/subcommands/csharp/init.rs
+++ b/vscodeconfigurator/src/subcommands/csharp/init.rs
@@ -68,8 +68,6 @@ impl InitCommandArgs {
     pub fn run_command(&self, console_utils: &mut ConsoleUtils) -> Result<(), Box<dyn std::error::Error>> {
         let mut output_directory = self.output_directory.clone();
 
-        console_utils.write_info(format!("{:?}\n", output_directory))?;
-
         output_directory = output_directory
             .resolve_home_dir()?
             .trim_trailing_slashes()?;
@@ -77,8 +75,6 @@ impl InitCommandArgs {
         output_directory.create_if_not_exists()?;
 
         let output_directory_absolute = output_directory.to_absolute();
-
-        console_utils.write_info(format!("{:?}\n", output_directory_absolute))?;
 
         let parsed_solution_name = self.get_solution_name_value();
 

--- a/vscodeconfigurator/src/subcommands/csharp/init.rs
+++ b/vscodeconfigurator/src/subcommands/csharp/init.rs
@@ -1,16 +1,7 @@
 use clap::{builder::TypedValueParser, Args, ValueEnum, ValueHint};
-use std::{
-    env,
-    path::{absolute, Path, PathBuf}
-};
 
 use crate::{
-    console_utils::ConsoleUtils,
-    error::{CliError, CliErrorKind},
-    external_procs::{dotnet, git},
-    template_ops,
-    utils,
-    vscode_ops
+    console_utils::ConsoleUtils, error::{CliError, CliErrorKind}, external_procs::{dotnet, git}, io::OutputDirectory, template_ops, vscode_ops
 };
 
 /// Defines the arguments for the `csharp init` command and the logic to run the command.
@@ -21,11 +12,11 @@ pub struct InitCommandArgs {
         short = 'o',
         long = "output-directory",
         required = false,
-        value_parser = clap::builder::OsStringValueParser::new().map(|s| PathBuf::from(s)),
-        default_value = utils::get_output_directory_default_value(),
+        value_parser = clap::builder::OsStringValueParser::new().map(|s| OutputDirectory::from_os_string(s).unwrap()),
+        default_value = OutputDirectory::from_current_dir(),
         value_hint = ValueHint::DirPath
     )]
-    output_directory: PathBuf,
+    output_directory: OutputDirectory,
 
     /// The name of the solution file.
     /// 
@@ -77,33 +68,17 @@ impl InitCommandArgs {
     pub fn run_command(&self, console_utils: &mut ConsoleUtils) -> Result<(), Box<dyn std::error::Error>> {
         let mut output_directory = self.output_directory.clone();
 
-        // Adding a check for the `~` character at the beginning of
-        // the output directory path. If it does, it will modify the
-        // path to use the user's home directory.
-        // 
-        // Might need to check if this is even necessary to do?
-        if self.output_directory.starts_with("~") {
-            let home_dir_env_var_key = match env::consts::OS {
-                "windows" => "USERPROFILE",
-                "unix" | "macos" => "HOME",
-                _ => return Err(CliError::new("The operating system is not supported.", CliErrorKind::UnsupportedOperatingSystem).into()),
-            };
-            let home_dir_env_var = env::var(home_dir_env_var_key).unwrap();
-            let home_dir = Path::new(&home_dir_env_var);
+        console_utils.write_info(format!("{:?}\n", output_directory))?;
 
-            output_directory =
-                PathBuf::from(&home_dir)
-                    .join(output_directory
-                        .strip_prefix("~")
-                        .unwrap()
-                    );
-        }
+        output_directory = output_directory
+            .resolve_home_dir()?
+            .trim_trailing_slashes()?;
 
-        if !output_directory.exists() {
-            std::fs::create_dir(&output_directory)?;
-        }
+        output_directory.create_if_not_exists()?;
 
-        let output_directory_absolute = absolute(output_directory).unwrap();
+        let output_directory_absolute = output_directory.to_absolute();
+
+        console_utils.write_info(format!("{:?}\n", output_directory_absolute))?;
 
         let parsed_solution_name = self.get_solution_name_value();
 
@@ -157,11 +132,18 @@ impl InitCommandArgs {
     fn get_solution_name_value(&self) -> Option<String> {
         match &self.solution_name.is_none() {
             true => {
-                let output_directory_name = self.output_directory
+                let output_directory_pathbuf = &self.output_directory
+                    .as_pathbuf();
+
+                let output_directory_name = output_directory_pathbuf
                     .file_name();
 
                 match output_directory_name {
-                    Some(name) => Some(name.to_string_lossy().to_string()),
+                    Some(name) => Some(
+                        name
+                            .to_string_lossy()
+                            .to_string()
+                    ),
                     None => None
                 }
             }

--- a/vscodeconfigurator/src/utils.rs
+++ b/vscodeconfigurator/src/utils.rs
@@ -1,11 +1,5 @@
 use std::{env, ffi::OsString, path::PathBuf};
 
-/// Gets the default value for the `output_directory` (`--output-directory`) argument if 
-/// it is not provided by the user.
-pub fn get_output_directory_default_value() -> OsString {
-    env::current_dir().unwrap().into_os_string()
-}
-
 /// Gets the path to the core templates directory.
 pub fn get_core_templates_path() -> PathBuf {
     let binary_path = env::current_exe().unwrap();


### PR DESCRIPTION
## Description

This is both a fix and an update. Whenever `--output-directory` was supplied with `./`, `.`, or a directory path ending in a `/`, it would fail to parse the solution name when using `csharp init`.

Though it is a fix, the `OutputDirectory` struct will come in handy for future subcommands added.

### Related issues

- None
