### PR TITLE
Add template files for Rust

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
     "task.autoDetect": "off",
-    "task.quickOpen.history": 0
+    "task.quickOpen.history": 0,
+    "files.associations": {
+        "**/vscodeconfigurator/src/templates/rust/Git/gitignore": "ignore"
+    }
 }

--- a/vscodeconfigurator/src/templates/rust/Cargo/Cargo.workspace.toml
+++ b/vscodeconfigurator/src/templates/rust/Cargo/Cargo.workspace.toml
@@ -1,0 +1,7 @@
+[workspace]
+members = []
+resolver = "2"
+
+package.authors = []
+package.homepage = ""
+package.repository = ""

--- a/vscodeconfigurator/src/templates/rust/Git/gitignore
+++ b/vscodeconfigurator/src/templates/rust/Git/gitignore
@@ -1,0 +1,7 @@
+# Cargo files
+debug/
+target/
+#Cargo.lock
+
+# macOS
+.DS_Store

--- a/vscodeconfigurator/src/templates/rust/Tools/Build-Package.ps1
+++ b/vscodeconfigurator/src/templates/rust/Tools/Build-Package.ps1
@@ -1,0 +1,31 @@
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0, Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$PackageName,
+    [Parameter(Position = 1)]
+    [ValidateSet(
+        "Debug",
+        "Release"
+    )]
+    [string]$BuildProfile = "Debug"
+)
+
+$cargoBuildArgs = [System.Collections.Generic.List[string]]::new()
+
+$cargoBuildArgs.Add("build")
+$cargoBuildArgs.Add("--package")
+$cargoBuildArgs.Add($PackageName)
+
+if ($BuildProfile -eq "Release") {
+    $cargoBuildArgs.Add("--release")
+}
+
+$cargoBuildProcSplat = @{
+    "FilePath" = "cargo";
+    "ArgumentList" = $cargoBuildArgs;
+    "NoNewWindow" = $true;
+    "Wait" = $true;
+    "ErrorAction" = "Stop";
+}
+Start-Process @cargoBuildProcSplat

--- a/vscodeconfigurator/src/templates/rust/Tools/Clean-Package.ps1
+++ b/vscodeconfigurator/src/templates/rust/Tools/Clean-Package.ps1
@@ -1,0 +1,31 @@
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0, Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$PackageName,
+    [Parameter(Position = 1)]
+    [ValidateSet(
+        "Debug",
+        "Release"
+    )]
+    [string]$BuildProfile = "Debug"
+)
+
+$cargoBuildArgs = [System.Collections.Generic.List[string]]::new()
+
+$cargoBuildArgs.Add("clean")
+$cargoBuildArgs.Add("--package")
+$cargoBuildArgs.Add($PackageName)
+
+if ($BuildProfile -eq "Release") {
+    $cargoBuildArgs.Add("--release")
+}
+
+$cargoBuildProcSplat = @{
+    "FilePath" = "cargo";
+    "ArgumentList" = $cargoBuildArgs;
+    "NoNewWindow" = $true;
+    "Wait" = $true;
+    "ErrorAction" = "Stop";
+}
+Start-Process @cargoBuildProcSplat

--- a/vscodeconfigurator/src/templates/rust/VSCode/settings.json
+++ b/vscodeconfigurator/src/templates/rust/VSCode/settings.json
@@ -1,0 +1,6 @@
+{
+    "debug.internalConsoleOptions": "neverOpen",
+    "git.detectSubmodules": false,
+    "task.quickOpen.history": 0,
+    "task.autoDetect": "off"
+}

--- a/vscodeconfigurator/src/templates/rust/VSCode/tasks.json
+++ b/vscodeconfigurator/src/templates/rust/VSCode/tasks.json
@@ -1,0 +1,97 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+			"label": "Build package",
+			"detail": "Build a package in the workspace",
+			"icon": {
+				"id": "tools",
+				"color": "terminal.ansiGreen"
+			},
+			"type": "process",
+			"command": "pwsh",
+			"args": [
+				"-NoLogo",
+                "-NoProfile",
+				"-File",
+				"${workspaceFolder}/tools/Build-Package.ps1",
+				"-PackageName",
+				"${input:packageName}",
+                "-BuildProfile",
+                "${input:buildProfile}",
+				"-Verbose"
+			],
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"presentation": {
+				"echo": true,
+				"reveal": "always",
+				"focus": true,
+				"panel": "shared",
+				"showReuseMessage": true,
+				"clear": true
+			},
+			"problemMatcher": "$rustc"
+		},
+        {
+            "label": "Clean package",
+            "detail": "Clean a package in the workspace",
+            "icon": {
+                "id": "trash",
+                "color": "terminal.ansiYellow"
+            },
+            "type": "process",
+			"command": "pwsh",
+			"args": [
+				"-NoLogo",
+                "-NoProfile",
+				"-File",
+				"${workspaceFolder}/tools/Clean-Package.ps1",
+				"-PackageName",
+				"${input:packageName}",
+                "-BuildProfile",
+                "${input:buildProfile}",
+				"-Verbose"
+			],
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"presentation": {
+				"echo": true,
+				"reveal": "always",
+				"focus": true,
+				"panel": "shared",
+				"showReuseMessage": true,
+				"clear": true
+			},
+			"problemMatcher": "$rustc"
+        }
+    ],
+    "inputs": [
+		{
+            "id": "packageName",
+            "type": "pickString",
+            "description": "Select a package to build",
+            "default": "",
+            "options": [
+            ]
+        },
+		{
+            "id": "buildProfile",
+            "description": "Select the build profile",
+            "type": "pickString",
+            "default": "Debug",
+            "options": [
+                {
+                    "label": "Debug",
+                    "value": "Debug"
+                },
+                {
+                    "label": "Release",
+                    "value": "Release"
+                }
+            ]
+        }
+	]
+}

--- a/vscodeconfigurator/src/templates/rust/VSCode/tasks.json
+++ b/vscodeconfigurator/src/templates/rust/VSCode/tasks.json
@@ -73,8 +73,12 @@
             "id": "packageName",
             "type": "pickString",
             "description": "Select a package to build",
-            "default": "",
+            "default": "{{basePackageName}}",
             "options": [
+				{
+					"label": "{{basePackageName}}",
+					"value": "{{basePackageName}}"
+				}
             ]
         },
 		{


### PR DESCRIPTION
## Description

- Adds template files to be used for Rust subcommands.

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#19 :point\_left:
    - \#21
      - \#22
