### PR TITLE
Update namespacing and module formatting

### DIFF
--- a/vscodeconfigurator/src/external_procs/cargo.rs
+++ b/vscodeconfigurator/src/external_procs/cargo.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::PathBuf, process};
 
-use crate::{console_utils::ConsoleUtils, subcommands::rust::init::CargoPackageTemplateOption};
+use crate::{console_utils::ConsoleUtils, subcommands::rust::CargoPackageTemplateOption};
 
 /// Initializes a new package with Cargo.
 ///

--- a/vscodeconfigurator/src/external_procs/mod.rs
+++ b/vscodeconfigurator/src/external_procs/mod.rs
@@ -1,3 +1,3 @@
+pub mod cargo;
 pub mod dotnet;
 pub mod git;
-pub mod cargo;

--- a/vscodeconfigurator/src/main.rs
+++ b/vscodeconfigurator/src/main.rs
@@ -1,11 +1,11 @@
-mod subcommands;
-mod external_procs;
 mod console_utils;
-mod template_ops;
-mod vscode_ops;
-mod utils;
 mod error;
+mod external_procs;
 mod io;
+mod subcommands;
+mod template_ops;
+mod utils;
+mod vscode_ops;
 
 use std::{error::Error, process};
 

--- a/vscodeconfigurator/src/subcommands/csharp/mod.rs
+++ b/vscodeconfigurator/src/subcommands/csharp/mod.rs
@@ -1,5 +1,5 @@
-mod init;
 mod add;
+mod init;
 
 pub use init::*;
 pub use add::*;

--- a/vscodeconfigurator/src/subcommands/csharp/mod.rs
+++ b/vscodeconfigurator/src/subcommands/csharp/mod.rs
@@ -1,11 +1,12 @@
-pub mod init;
-pub mod add;
+mod init;
+mod add;
+
+pub use init::*;
+pub use add::*;
 
 use std::error::Error;
 
 use clap::Subcommand;
-use init::InitCommandArgs;
-use add::AddCommandArgs;
 
 use crate::console_utils::ConsoleUtils;
 

--- a/vscodeconfigurator/src/subcommands/csharp/mod.rs
+++ b/vscodeconfigurator/src/subcommands/csharp/mod.rs
@@ -1,8 +1,12 @@
 mod add;
 mod init;
 
-pub use init::*;
-pub use add::*;
+pub use init::CsharpLspOption;
+
+use self::{
+    add::AddCommandArgs,
+    init::InitCommandArgs
+};
 
 use std::error::Error;
 

--- a/vscodeconfigurator/src/subcommands/rust/mod.rs
+++ b/vscodeconfigurator/src/subcommands/rust/mod.rs
@@ -1,5 +1,5 @@
-mod init;
 mod add;
+mod init;
 
 pub use init::*;
 pub use add::*;

--- a/vscodeconfigurator/src/subcommands/rust/mod.rs
+++ b/vscodeconfigurator/src/subcommands/rust/mod.rs
@@ -1,10 +1,12 @@
-pub mod init;
-pub mod add;
+mod init;
+mod add;
+
+pub use init::*;
+pub use add::*;
 
 use std::error::Error;
 
 use clap::Subcommand;
-use init::RustInitCommandArgs;
 
 use crate::console_utils::ConsoleUtils;
 
@@ -27,7 +29,7 @@ pub enum RustSubcommands {
         about = "Add a new package to a Rust project.",
         long_about = None
     )]
-    Add(add::RustAddCommandArgs),
+    Add(RustAddCommandArgs),
 }
 
 impl RustSubcommands {

--- a/vscodeconfigurator/src/subcommands/rust/mod.rs
+++ b/vscodeconfigurator/src/subcommands/rust/mod.rs
@@ -1,8 +1,12 @@
 mod add;
 mod init;
 
-pub use init::*;
-pub use add::*;
+pub use init::CargoPackageTemplateOption;
+
+use self::{
+    add::RustAddCommandArgs,
+    init::RustInitCommandArgs
+};
 
 use std::error::Error;
 

--- a/vscodeconfigurator/src/template_ops/mod.rs
+++ b/vscodeconfigurator/src/template_ops/mod.rs
@@ -1,3 +1,3 @@
 pub mod csharp;
-pub mod vscode;
 pub mod rust;
+pub mod vscode;

--- a/vscodeconfigurator/src/vscode_ops/csharp.rs
+++ b/vscodeconfigurator/src/vscode_ops/csharp.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 
 use crate::{
     console_utils::ConsoleUtils,
-    subcommands::csharp::init::CsharpLspOption,
+    subcommands::csharp::CsharpLspOption,
     vscode_ops::{VSCodeSettings, VSCodeTasks}
 };
 


### PR DESCRIPTION
## Description

- Changes access modifiers for Rust and C# subcommand modules.
- Format module listings in alphabetical order.

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#26 :point\_left:
