### PR TITLE
Replace regex with regex-lite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,33 +323,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.11.0"
+name = "regex-lite"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "rustix"
@@ -508,7 +476,7 @@ dependencies = [
  "clap_complete",
  "crossterm",
  "git-version",
- "regex",
+ "regex-lite",
  "serde_json",
  "toml_edit",
 ]

--- a/vscodeconfigurator/Cargo.toml
+++ b/vscodeconfigurator/Cargo.toml
@@ -19,7 +19,7 @@ build = "build.rs"
 clap = { version = "4.5.20", features = ["derive", "string", "cargo"] }
 clap_complete = "4.5.33"
 crossterm = { version = "0.28.1", features = ["events"] }
-regex = "1.11.0"
+regex-lite = "0.1.6"
 serde_json = { version = "1.0.128", features = ["preserve_order"] }
 
 [build-dependencies]

--- a/vscodeconfigurator/src/console_utils.rs
+++ b/vscodeconfigurator/src/console_utils.rs
@@ -31,7 +31,7 @@ use crossterm::{
     },
     tty::IsTty
 };
-use regex::Regex;
+use regex_lite::Regex;
 
 /// Utility for writing to the console.
 pub struct ConsoleUtils {


### PR DESCRIPTION
## Description

- Replaces the `regex` crate with `regex-lite`. Reduces the final binary size significantly.

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#29 :point\_left:
