### PR TITLE
Rename VSCode structs

### DIFF
--- a/vscodeconfigurator/src/vscode_ops/csharp.rs
+++ b/vscodeconfigurator/src/vscode_ops/csharp.rs
@@ -5,7 +5,7 @@ use serde_json::{json, Value};
 use crate::{
     console_utils::ConsoleUtils,
     subcommands::csharp::CsharpLspOption,
-    vscode_ops::{VSCodeSettings, VSCodeTasks}
+    vscode_ops::{VSCodeSettingsFile, VSCodeTasksFile}
 };
 
 /// Updates the C# LSP option in the `.vscode/settings.json` file.
@@ -22,7 +22,7 @@ pub fn update_csharp_lsp(
 ) -> Result<(), Box<dyn std::error::Error>> {
     console_utils.write_info(format!("- 📄 Updating C# LSP option in tasks.json... "))?;
 
-    let mut vscode_settings = VSCodeSettings::new(output_directory.join(".vscode/settings.json"));
+    let mut vscode_settings = VSCodeSettingsFile::new(output_directory.join(".vscode/settings.json"));
 
     vscode_settings.values["dotnet.server.useOmnisharp"] = match csharp_lsp {
         CsharpLspOption::CsharpLsp => Value::Bool(false),
@@ -61,7 +61,7 @@ pub fn add_csharp_project_to_tasks(
 ) -> Result<(), Box<dyn std::error::Error>> {
     console_utils.write_info(format!("- 📄 Adding C# project to tasks.json... "))?;
 
-    let mut vscode_tasks = VSCodeTasks::new(output_directory.join(".vscode/tasks.json"));
+    let mut vscode_tasks = VSCodeTasksFile::new(output_directory.join(".vscode/tasks.json"));
 
     let inputs_node = vscode_tasks.values["inputs"].as_array_mut().unwrap();
 

--- a/vscodeconfigurator/src/vscode_ops/mod.rs
+++ b/vscodeconfigurator/src/vscode_ops/mod.rs
@@ -11,12 +11,12 @@ use serde_json::Value;
 /// 
 /// * `file_path` - The path to the settings file.
 /// * `values` - The values in the settings file.
-pub struct VSCodeSettings {
+pub struct VSCodeSettingsFile {
     pub file_path: PathBuf,
     pub values: Value
 }
 
-impl VSCodeSettings {
+impl VSCodeSettingsFile {
     /// Creates a new `VSCodeSettings` instance.
     /// 
     /// ## Arguments
@@ -49,7 +49,7 @@ impl VSCodeSettings {
 }
 
 /// Represents the tasks file for a Visual Studio Code workspace.
-pub struct VSCodeTasks {
+pub struct VSCodeTasksFile {
     /// The path to the tasks file.
     pub file_path: PathBuf,
 
@@ -57,7 +57,7 @@ pub struct VSCodeTasks {
     pub values: Value
 }
 
-impl VSCodeTasks {
+impl VSCodeTasksFile {
     /// Creates a new `VSCodeTasks` instance.
     /// 
     /// ## Arguments

--- a/vscodeconfigurator/src/vscode_ops/rust.rs
+++ b/vscodeconfigurator/src/vscode_ops/rust.rs
@@ -4,7 +4,7 @@ use serde_json::json;
 
 use crate::{
     console_utils::ConsoleUtils,
-    vscode_ops::VSCodeTasks
+    vscode_ops::VSCodeTasksFile
 };
 
 
@@ -24,7 +24,7 @@ pub fn add_package_to_tasks(
 ) -> Result<(), Box<dyn std::error::Error>> {
     console_utils.write_info(format!("- 📄 Adding package to tasks.json... "))?;
 
-    let mut vscode_tasks = VSCodeTasks::new(output_directory.join(".vscode/tasks.json"));
+    let mut vscode_tasks = VSCodeTasksFile::new(output_directory.join(".vscode/tasks.json"));
 
     let inputs_node = vscode_tasks.values["inputs"].as_array_mut().unwrap();
 


### PR DESCRIPTION
## Description

- `VSCodeSettings` is now `VSCodeSettingsFile`.
- `VSCodeTasks` is now `VSCodeTasksFile`.

This better aligns with what exactly they are.

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#30 :point\_left:
