### PR TITLE
Rework emoji outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,12 +323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-lite"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
-
-[[package]]
 name = "rustix"
 version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,7 +470,6 @@ dependencies = [
  "clap_complete",
  "crossterm",
  "git-version",
- "regex-lite",
  "serde_json",
  "toml_edit",
 ]

--- a/vscodeconfigurator/Cargo.toml
+++ b/vscodeconfigurator/Cargo.toml
@@ -19,7 +19,6 @@ build = "build.rs"
 clap = { version = "4.5.20", features = ["derive", "string", "cargo"] }
 clap_complete = "4.5.33"
 crossterm = { version = "0.28.1", features = ["events"] }
-regex-lite = "0.1.6"
 serde_json = { version = "1.0.128", features = ["preserve_order"] }
 
 [build-dependencies]

--- a/vscodeconfigurator/src/console_utils.rs
+++ b/vscodeconfigurator/src/console_utils.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, io::{Result, Stderr, Stdout, Write}, process};
+use std::{io::{Result, Stderr, Stdout, Write}, process};
 
 use crossterm::{
     cursor::{
@@ -31,15 +31,12 @@ use crossterm::{
     },
     tty::IsTty
 };
-use regex_lite::Regex;
 
 /// Utility for writing to the console.
 pub struct ConsoleUtils {
     pub stdout: Stdout,
 
-    pub stderr: Stderr,
-
-    unicode_remove_regex: Regex
+    pub stderr: Stderr
 }
 
 #[allow(dead_code)]
@@ -62,21 +59,7 @@ impl ConsoleUtils {
 
         Self {
             stdout: stdout_item,
-            stderr: stderr_item,
-            unicode_remove_regex: Regex::new(concat!(
-                "[",
-                "\u{1F680}", // 🚀
-                "\u{1F4C4}", // 📄
-                "\u{2705}", // ✅
-                "\u{1F7E0}", // 🟠
-                "\u{1F4C1}", // 📁
-                "\u{1F4E6}", // 📦
-                "\u{1F973}", // 🥳
-                "\u{270B}", // ✋
-                "\u{1F6D1}", // 🛑
-                "\u{1F6A8}", // 🚨
-                "]"
-            )).unwrap()
+            stderr: stderr_item
         }
     }
 

--- a/vscodeconfigurator/src/console_utils.rs
+++ b/vscodeconfigurator/src/console_utils.rs
@@ -376,3 +376,55 @@ impl ConsoleUtils {
         self.stderr.flush().unwrap();
     }
 }
+
+/// An emoji to use in the console.
+#[allow(dead_code)]
+pub enum OutputEmoji {
+    /// 🚀
+    Rocket,
+
+    /// 📄
+    Document,
+
+    /// ✅
+    CheckMark,
+
+    /// 🟠
+    OrangeCircle,
+
+    /// 📁
+    Folder,
+
+    /// 📦
+    Package,
+
+    /// 🥳
+    Party,
+
+    /// ✋
+    Hand,
+
+    /// 🛑
+    Stop,
+
+    /// 🚨
+    Siren
+}
+
+impl std::fmt::Display for OutputEmoji {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let emoji = match self {
+            OutputEmoji::Rocket => "🚀",
+            OutputEmoji::Document => "📄",
+            OutputEmoji::CheckMark => "✅",
+            OutputEmoji::OrangeCircle => "🟠",
+            OutputEmoji::Folder => "📁",
+            OutputEmoji::Package => "📦",
+            OutputEmoji::Party => "🥳",
+            OutputEmoji::Hand => "✋",
+            OutputEmoji::Stop => "🛑",
+            OutputEmoji::Siren => "🚨"
+        };
+        write!(f, "{}", emoji)
+    }
+}

--- a/vscodeconfigurator/src/console_utils.rs
+++ b/vscodeconfigurator/src/console_utils.rs
@@ -66,12 +66,9 @@ impl ConsoleUtils {
     /// Write an informational message to the console.
     pub fn write_info(&mut self, message: String) -> Result<()> {
         if !self.stdout.is_tty() {
-            let message_noemojis = &self.remove_emojis(&message);
-            let message_noemojis = message_noemojis.trim_start();
-
             execute!(
                 self.stdout,
-                Print(format!("[Info] - {}", &message_noemojis))
+                Print(format!("[Info] - {}", message))
             )?;
 
             return Ok(());
@@ -88,12 +85,9 @@ impl ConsoleUtils {
     /// Write a success message to the console.
     pub fn write_success(&mut self, message: String) -> Result<()> {
         if !self.stdout.is_tty() {
-            let message_noemojis = self.remove_emojis(&message);
-            let message_noemojis = message_noemojis.trim_start();
-
             execute!(
                 self.stdout,
-                Print(format!("{}", &message_noemojis))
+                Print(format!("{}", &message))
             )?;
 
             return Ok(());
@@ -110,12 +104,9 @@ impl ConsoleUtils {
     /// Write a warning message to the console.
     pub fn write_warning(&mut self, message: String) -> Result<()> {
         if !self.stdout.is_tty() {
-            let message_noemojis = self.remove_emojis(&message);
-            let message_noemojis = message_noemojis.trim_start();
-
             execute!(
                 self.stdout,
-                Print(format!("[Warning] - {}", &message_noemojis))
+                Print(format!("[Warning] - {}", &message))
             )?;
 
             return Ok(());
@@ -132,12 +123,9 @@ impl ConsoleUtils {
     /// Write an error message to the console.
     pub fn write_error(&mut self, message: String) -> Result<()> {
         if !self.stdout.is_tty() {
-            let message_noemojis = self.remove_emojis(&message);
-            let message_noemojis = message_noemojis.trim_start();
-
             execute!(
                 self.stdout,
-                Print(format!("[Error] - {}", &message_noemojis))
+                Print(format!("[Error] - {}", &message))
             )?;
 
             return Ok(());
@@ -346,10 +334,82 @@ impl ConsoleUtils {
         Ok(result)
     }
 
-    /// Remove emojis from a message.
-    fn remove_emojis<'a>(&self, message: &'a str) -> Cow<'a, str> {
-        self.unicode_remove_regex
-            .replace_all(&message, "")
+    /// Write a newline to the console.
+    pub fn write_newline(&mut self) -> Result<()> {
+        execute!(self.stdout, Print("\n"))
+    }
+
+    /// Writes an operation category header to the console.
+    /// 
+    /// ### Arguments
+    /// 
+    /// * `category` - The category of the operation.
+    /// 
+    /// ### Example
+    /// 
+    /// ```rust
+    /// console_utils.write_operation_category("Installing dependencies")?; // "🚀 Installing dependencies"
+    /// ```
+    pub fn write_operation_category(&mut self, name: &str) -> Result<()> {
+        let message = match self.stdout.is_tty() {
+            false => format!("{}\n", name),
+            true => format!("{} {}\n", OutputEmoji::Rocket, name)
+        };
+
+        self.write_info(message)
+    }
+
+    /// Writes an operation log to the console.
+    /// 
+    /// ### Arguments
+    /// 
+    /// * `message` - The message to write.
+    /// * `emoji` - The emoji to use.
+    /// 
+    /// ### Example
+    /// 
+    /// ```rust
+    /// console_utils.write_operation_log("Adding package to tasks.json...", OutputEmoji::Document)?; // "📄 Adding package to tasks.json... "
+    /// ```
+    pub fn write_operation_log(&mut self, message: &str, emoji: OutputEmoji) -> Result<()> {
+        let message = match self.stdout.is_tty() {
+            false => format!("- {} ", message),
+            true => format!("- {} {} ", emoji, message)
+        };
+
+        self.write_info(message)
+    }
+
+    /// Writes an operation success log to the console.
+    /// 
+    /// ### Example
+    /// 
+    /// ```rust
+    /// console_utils.write_operation_success_log()?; // "Done! ✅"
+    /// ```
+    pub fn write_operation_success_log(&mut self) -> Result<()> {
+        let message = match self.stdout.is_tty() {
+            false => format!("Done!\n"),
+            true => format!("Done! {}\n", OutputEmoji::CheckMark)
+        };
+
+        self.write_success(message)
+    }
+
+    /// Writes a project initialized log to the console.
+    /// 
+    /// ### Example
+    /// 
+    /// ```rust
+    /// console_utils.write_project_initialized_log()?; // "🥳 VSCode project initialized!"
+    /// ```
+    pub fn write_project_initialized_log(&mut self) -> Result<()> {
+        let message = match self.stdout.is_tty() {
+            false => format!("VSCode project initialized!\n"),
+            true => format!("{} VSCode project initialized!\n", OutputEmoji::Party)
+        };
+
+        self.write_info(message)
     }
 
     /// Flush and release the standard output stream.

--- a/vscodeconfigurator/src/external_procs/cargo.rs
+++ b/vscodeconfigurator/src/external_procs/cargo.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::PathBuf, process};
 
-use crate::{console_utils::ConsoleUtils, subcommands::rust::CargoPackageTemplateOption};
+use crate::{console_utils::{ConsoleUtils, OutputEmoji}, subcommands::rust::CargoPackageTemplateOption};
 
 /// Initializes a new package with Cargo.
 ///
@@ -17,7 +17,10 @@ pub fn initalize_package(
     force: bool,
     console_utils: &mut ConsoleUtils,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    console_utils.write_info(format!("- 📦 Initializing package for '{}'... ", package_name))?;
+    console_utils.write_operation_log(
+        format!("Initializing package for '{}'... ", package_name).as_str(),
+        OutputEmoji::Package
+    )?;
     console_utils.save_cursor_position()?;
 
     let package_output_directory = output_directory
@@ -59,7 +62,7 @@ pub fn initalize_package(
         .current_dir(output_directory)
         .output()?;
 
-    console_utils.write_success(format!("Done! ✅\n"))?;
+    console_utils.write_operation_success_log()?;
 
     Ok(())
 }

--- a/vscodeconfigurator/src/external_procs/dotnet.rs
+++ b/vscodeconfigurator/src/external_procs/dotnet.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::PathBuf, process};
 
-use crate::console_utils::ConsoleUtils;
+use crate::console_utils::{ConsoleUtils, OutputEmoji};
 
 /// Initializes a new .NET solution.
 ///
@@ -15,10 +15,10 @@ pub fn initalize_dotnet_solution(
     force: bool,
     console_utils: &mut ConsoleUtils,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    console_utils.write_info(format!(
-        "- 📦 Initializing .NET solution '{:}.sln'... ",
-        solution_name
-    ))?;
+    console_utils.write_operation_log(
+        format!("Initializing .NET solution '{:}.sln'...", solution_name).as_str(),
+        OutputEmoji::Package
+    )?;
     console_utils.save_cursor_position()?;
 
     let output_file_name = format!("{:}.sln", &solution_name);
@@ -48,7 +48,7 @@ pub fn initalize_dotnet_solution(
         .current_dir(output_directory)
         .output()?;
 
-    console_utils.write_success(format!("Done! ✅\n"))?;
+    console_utils.write_operation_success_log()?;
 
     Ok(())
 }
@@ -64,7 +64,7 @@ pub fn add_dotnet_globaljson(
     force: bool,
     console_utils: &mut ConsoleUtils,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    console_utils.write_info(format!("- 📄 Adding 'global.json' to project root... "))?;
+    console_utils.write_operation_log("Adding 'global.json' to project root...", OutputEmoji::Document)?;
     console_utils.save_cursor_position()?;
 
     let output_file_name = "global.json";
@@ -94,7 +94,7 @@ pub fn add_dotnet_globaljson(
         .current_dir(output_directory)
         .output()?;
 
-    console_utils.write_success(format!("Done! ✅\n"))?;
+    console_utils.write_operation_success_log()?;
 
     Ok(())
 }
@@ -110,7 +110,7 @@ pub fn add_dotnet_gitignore(
     force: bool,
     console_utils: &mut ConsoleUtils,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    console_utils.write_info(format!("- 📄 Adding '.gitignore' to project root... "))?;
+    console_utils.write_operation_log("Adding '.gitignore' to project root...", OutputEmoji::Document)?;
     console_utils.save_cursor_position()?;
 
     let output_file_name = ".gitignore";
@@ -140,7 +140,7 @@ pub fn add_dotnet_gitignore(
         .current_dir(output_directory)
         .output()?;
 
-    console_utils.write_success(format!("Done! ✅\n"))?;
+    console_utils.write_operation_success_log()?;
 
     Ok(())
 }
@@ -156,7 +156,7 @@ pub fn add_dotnet_buildprops(
     force: bool,
     console_utils: &mut ConsoleUtils,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    console_utils.write_info(format!("- 📄 Adding 'Directory.Build.props' to project root... "))?;
+    console_utils.write_operation_log("Adding 'Directory.Build.props' to project root...", OutputEmoji::Document)?;
     console_utils.save_cursor_position()?;
 
     let output_file_name = "Directory.Build.props";
@@ -186,7 +186,7 @@ pub fn add_dotnet_buildprops(
         .current_dir(output_directory)
         .output()?;
 
-    console_utils.write_success(format!("Done! ✅\n"))?;
+    console_utils.write_operation_success_log()?;
 
     Ok(())
 }
@@ -202,7 +202,7 @@ pub fn add_dotnet_nugetconfig(
     force: bool,
     console_utils: &mut ConsoleUtils,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    console_utils.write_info(format!("- 📄 Adding 'NuGet.Config' to project root... "))?;
+    console_utils.write_operation_log("Adding 'NuGet.Config' to project root...", OutputEmoji::Document)?;
     console_utils.save_cursor_position()?;
 
     let output_file_name = "NuGet.Config";
@@ -232,7 +232,7 @@ pub fn add_dotnet_nugetconfig(
         .current_dir(output_directory)
         .output()?;
 
-    console_utils.write_success(format!("Done! ✅\n"))?;
+    console_utils.write_operation_success_log()?;
 
     Ok(())
 }
@@ -248,7 +248,7 @@ pub fn add_dotnet_packagesprops(
     force: bool,
     console_utils: &mut ConsoleUtils,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    console_utils.write_info(format!("- 📄 Adding 'Directory.Packages.props' to project root... "))?;
+    console_utils.write_operation_log("Adding 'Directory.Packages.props' to project root...", OutputEmoji::Document)?;
     console_utils.save_cursor_position()?;
 
     let output_file_name = "Directory.Packages.props";
@@ -278,7 +278,7 @@ pub fn add_dotnet_packagesprops(
         .current_dir(output_directory)
         .output()?;
 
-    console_utils.write_success(format!("Done! ✅\n"))?;
+    console_utils.write_operation_success_log()?;
 
     Ok(())
 }
@@ -306,7 +306,7 @@ pub fn add_dotnet_tool(
         .current_dir(output_directory)
         .output()?;
 
-    console_utils.write_success(format!("Done! ✅\n"))?;
+    console_utils.write_operation_success_log()?;
 
     Ok(())
 }
@@ -331,7 +331,7 @@ fn initialize_dotnet_tool_manifest(
         return Ok(());
     }
 
-    console_utils.write_info(format!("- 📦 Initializing .NET tool manifiest... "))?;
+    console_utils.write_operation_log("Initializing .NET tool manifiest...", OutputEmoji::Package)?;
     console_utils.save_cursor_position()?;
 
     let dotnet_proc_args = vec!["new", "tool-manifest"];
@@ -341,7 +341,7 @@ fn initialize_dotnet_tool_manifest(
         .current_dir(output_directory)
         .output()?;
 
-    console_utils.write_success(format!("Done! ✅\n"))?;
+    console_utils.write_operation_success_log()?;
 
     Ok(())
 }
@@ -370,7 +370,7 @@ pub fn add_project_to_solution(
         .args(dotnet_proc_args)
         .output()?;
 
-    console_utils.write_success(format!("Done! ✅\n"))?;
+    console_utils.write_operation_success_log()?;
 
     Ok(())
 }

--- a/vscodeconfigurator/src/external_procs/git.rs
+++ b/vscodeconfigurator/src/external_procs/git.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::console_utils::ConsoleUtils;
+use crate::console_utils::{ConsoleUtils, OutputEmoji};
 
 /// Initializes a Git repository in the output directory.
 /// 
@@ -12,7 +12,7 @@ pub fn initialize_git_repo(
     output_directory: &PathBuf,
     console_utils: &mut ConsoleUtils
 ) -> Result<(), Box<dyn std::error::Error>> {
-    console_utils.write_info(format!("- 📦 Initializing Git repository... "))?;
+    console_utils.write_operation_log("Initializing Git repository...", OutputEmoji::Package)?;
     
     let git_proc_args = vec![
         "init"
@@ -23,6 +23,6 @@ pub fn initialize_git_repo(
         .current_dir(output_directory)
         .output()?;
 
-    console_utils.write_success(format!("Done! ✅\n"))?;
+    console_utils.write_operation_success_log()?;
     Ok(())
 }

--- a/vscodeconfigurator/src/subcommands/csharp/add.rs
+++ b/vscodeconfigurator/src/subcommands/csharp/add.rs
@@ -102,7 +102,7 @@ impl AddCommandArgs {
             project_friendly_name = self.project_friendly_name.clone().unwrap();
         }
 
-        console_utils.write_info(format!("🚀 Add project\n"))?;
+        console_utils.write_operation_category("Add project")?;
         dotnet::add_project_to_solution(&solution_file_path, &self.project_path, console_utils)?;
         vscode_ops::csharp::add_csharp_project_to_tasks(&PathBuf::from(solution_file_path.parent().unwrap()), &self.project_path, &project_friendly_name, self.is_runnable, self.is_watchable, console_utils)?;
 

--- a/vscodeconfigurator/src/subcommands/csharp/init.rs
+++ b/vscodeconfigurator/src/subcommands/csharp/init.rs
@@ -97,14 +97,16 @@ impl InitCommandArgs {
 
         let solution_name = parsed_solution_name.unwrap();
 
-        console_utils.write_info(format!("🚀 Basic\n"))?;
+        console_utils.write_operation_category("Basic")?;
         dotnet::add_dotnet_globaljson(&output_directory_absolute, self.force, console_utils)?;
+        console_utils.write_newline()?;
 
-        console_utils.write_info(format!("\n🚀 Git\n"))?;
+        console_utils.write_operation_category("Git")?;
         git::initialize_git_repo(&output_directory_absolute, console_utils)?;
         dotnet::add_dotnet_gitignore(&output_directory_absolute, self.force, console_utils)?;
+        console_utils.write_newline()?;
 
-        console_utils.write_info(format!("\n🚀 .NET\n"))?;
+        console_utils.write_operation_category(".NET")?;
         dotnet::initalize_dotnet_solution(&output_directory_absolute, &solution_name, self.force, console_utils)?;
         dotnet::add_dotnet_buildprops(&output_directory_absolute, self.force, console_utils)?;
 
@@ -116,18 +118,22 @@ impl InitCommandArgs {
             dotnet::add_dotnet_packagesprops(&output_directory_absolute, self.force, console_utils)?;
         }
 
+        console_utils.write_newline()?;
+
         if self.add_gitversion {
-            console_utils.write_info(format!("\n🚀 GitVersion\n"))?;
+            console_utils.write_operation_category("GitVersion")?;
             dotnet::add_dotnet_tool(&output_directory_absolute, "GitVersion.Tool", console_utils)?;
             template_ops::csharp::csharp_copy_gitversion(&output_directory_absolute, self.force, console_utils)?;
+            console_utils.write_newline()?;
         }
 
-        console_utils.write_info(format!("\n🚀 VSCode\n"))?;
+        console_utils.write_operation_category("VSCode")?;
         template_ops::csharp::csharp_copy_vscode_settings(&output_directory_absolute, &solution_name, self.force, console_utils)?;
         vscode_ops::csharp::update_csharp_lsp(&output_directory_absolute, self.csharp_lsp, console_utils)?;
         template_ops::csharp::csharp_copy_vscode_tasks(&output_directory_absolute, &solution_name, self.force, console_utils)?;
+        console_utils.write_newline()?;
 
-        console_utils.write_info(format!("\n🥳 VSCode project initialized!\n"))?;
+        console_utils.write_project_initialized_log()?;
 
         Ok(())
     }

--- a/vscodeconfigurator/src/subcommands/rust/add.rs
+++ b/vscodeconfigurator/src/subcommands/rust/add.rs
@@ -56,7 +56,7 @@ impl RustAddCommandArgs {
             None => self.package_name.as_str()
         };
 
-        console_utils.write_info(format!("🚀 Add project\n"))?;
+        console_utils.write_operation_category("Add package")?;
         vscode_ops::rust::add_package_to_tasks(&output_directory_absolute, self.package_name.as_str(), package_friendly_name, console_utils)?;
 
         Ok(())

--- a/vscodeconfigurator/src/subcommands/rust/init.rs
+++ b/vscodeconfigurator/src/subcommands/rust/init.rs
@@ -56,21 +56,24 @@ impl RustInitCommandArgs {
 
         let output_directory_absolute = output_directory.to_absolute();
 
-        console_utils.write_info(format!("🚀 Git\n"))?;
+        console_utils.write_operation_category("Git")?;
         git::initialize_git_repo(&output_directory_absolute, console_utils)?;
         template_ops::rust::copy_gitignore(&output_directory_absolute, self.force, console_utils)?;
+        console_utils.write_newline()?;
 
-        console_utils.write_info(format!("\n🚀 VSCode\n"))?;
+        console_utils.write_operation_category("VSCode")?;
         template_ops::rust::copy_vscode_settings(&output_directory_absolute, self.force, console_utils)?;
         template_ops::rust::copy_vscode_tasks(&output_directory_absolute, &self.base_package_name, self.force, console_utils)?;
         template_ops::rust::copy_build_pwsh_script(&output_directory_absolute, self.force, console_utils)?;
         template_ops::rust::copy_clean_pwsh_script(&output_directory_absolute, self.force, console_utils)?;
+        console_utils.write_newline()?;
 
-        console_utils.write_info(format!("\n🚀 Rust\n"))?;
+        console_utils.write_operation_category("Rust")?;
         template_ops::rust::copy_cargo_workspace_file(&output_directory_absolute, self.force, console_utils)?;
         cargo::initalize_package(&output_directory_absolute, &self.base_package_name, self.base_package_template, self.force, console_utils)?;
+        console_utils.write_newline()?;
 
-        console_utils.write_info(format!("\n🥳 VSCode project initialized!\n"))?;
+        console_utils.write_project_initialized_log()?;
 
         Ok(())
     }

--- a/vscodeconfigurator/src/template_ops/csharp.rs
+++ b/vscodeconfigurator/src/template_ops/csharp.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::PathBuf};
 
-use crate::{console_utils::ConsoleUtils, utils};
+use crate::{console_utils::{ConsoleUtils, OutputEmoji}, utils};
 
 use super::vscode;
 
@@ -18,7 +18,7 @@ pub fn csharp_copy_gitversion(output_directory: &PathBuf, force: bool, console_u
     let output_file_name = "GitVersion.yml";
     let output_file_path = output_directory.join(&output_file_name);
 
-    console_utils.write_info(format!("- 📄 Copying 'GitVersion.yml' to project root... "))?;
+    console_utils.write_operation_log("Copying 'GitVersion.yml' to project root...", OutputEmoji::Document)?;
 
     if output_file_path.exists() {
         if !force {
@@ -39,7 +39,7 @@ pub fn csharp_copy_gitversion(output_directory: &PathBuf, force: bool, console_u
 
     fs::copy(template_file_path, &output_file_path)?;
 
-    console_utils.write_success(format!("Done! ✅\n"))?;
+    console_utils.write_operation_success_log()?;
 
     Ok(())
 }
@@ -61,7 +61,7 @@ pub fn csharp_copy_vscode_settings(output_directory: &PathBuf, solution_name: &S
     let output_file_name = "settings.json";
     let output_file_path = output_directory.join(".vscode").join(&output_file_name);
 
-    console_utils.write_info(format!("- 📄 Copying 'settings.json' to '.vscode' directory... "))?;
+    console_utils.write_operation_log("Copying 'settings.json' to '.vscode' directory...", OutputEmoji::Document)?;
 
     if output_file_path.exists() {
         if !force {
@@ -86,7 +86,7 @@ pub fn csharp_copy_vscode_settings(output_directory: &PathBuf, solution_name: &S
 
     fs::write(&output_file_path, vscode_settings_json)?;
 
-    console_utils.write_success(format!("Done! ✅\n"))?;
+    console_utils.write_operation_success_log()?;
 
     Ok(())
 }
@@ -108,7 +108,7 @@ pub fn csharp_copy_vscode_tasks(output_directory: &PathBuf, solution_name: &Stri
     let output_file_name = "tasks.json";
     let output_file_path = output_directory.join(".vscode").join(&output_file_name);
 
-    console_utils.write_info(format!("- 📄 Copying 'tasks.json' to '.vscode' directory... "))?;
+    console_utils.write_operation_log("Copying 'tasks.json' to '.vscode' directory...", OutputEmoji::Document)?;
 
     if output_file_path.exists() {
         if !force {
@@ -133,7 +133,7 @@ pub fn csharp_copy_vscode_tasks(output_directory: &PathBuf, solution_name: &Stri
 
     fs::write(&output_file_path, vscode_tasks_json)?;
 
-    console_utils.write_success(format!("Done! ✅\n"))?;
+    console_utils.write_operation_success_log()?;
 
     Ok(())
 }

--- a/vscodeconfigurator/src/template_ops/rust.rs
+++ b/vscodeconfigurator/src/template_ops/rust.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::PathBuf};
 
-use crate::{console_utils::ConsoleUtils, utils};
+use crate::{console_utils::{ConsoleUtils, OutputEmoji}, utils};
 
 use super::vscode;
 
@@ -22,10 +22,7 @@ pub fn copy_gitignore(
     let output_file_name = ".gitignore";
     let output_file_path = output_directory.join(&output_file_name);
 
-    console_utils.write_info(format!(
-        "- 📄 Copying '{}' to project root... ",
-        output_file_name
-    ))?;
+    console_utils.write_operation_log("Copying '.gitignore' to project root...", OutputEmoji::Document)?;
 
     if output_file_path.exists() {
         if !force {
@@ -46,7 +43,7 @@ pub fn copy_gitignore(
 
     fs::copy(template_file_path, &output_file_path)?;
 
-    console_utils.write_success(format!("Done! ✅\n"))?;
+    console_utils.write_operation_success_log()?;
 
     Ok(())
 }
@@ -69,10 +66,7 @@ pub fn copy_cargo_workspace_file(
     let output_file_name = "Cargo.toml";
     let output_file_path = output_directory.join(&output_file_name);
 
-    console_utils.write_info(format!(
-        "- 📄 Copying '{}' to project root... ",
-        output_file_name
-    ))?;
+    console_utils.write_operation_log("Copying 'Cargo.toml' to project root...", OutputEmoji::Document)?;
 
     if output_file_path.exists() {
         if !force {
@@ -93,7 +87,7 @@ pub fn copy_cargo_workspace_file(
 
     fs::copy(template_file_path, &output_file_path)?;
 
-    console_utils.write_success(format!("Done! ✅\n"))?;
+    console_utils.write_operation_success_log()?;
 
     Ok(())
 }
@@ -118,10 +112,7 @@ pub fn copy_vscode_settings(
     let output_file_name = "settings.json";
     let output_file_path = output_directory.join(".vscode").join(&output_file_name);
 
-    console_utils.write_info(format!(
-        "- 📄 Copying '{}' to '.vscode' directory... ",
-        output_file_name
-    ))?;
+    console_utils.write_operation_log("Copying 'settings.json' to '.vscode' directory...", OutputEmoji::Document)?;
 
     if output_file_path.exists() {
         if !force {
@@ -143,7 +134,7 @@ pub fn copy_vscode_settings(
     let vscode_settings_json = fs::read_to_string(&template_file_path)?;
     fs::write(&output_file_path, vscode_settings_json)?;
 
-    console_utils.write_success(format!("Done! ✅\n"))?;
+    console_utils.write_operation_success_log()?;
 
     Ok(())
 }
@@ -170,10 +161,7 @@ pub fn copy_vscode_tasks(
     let output_file_name = "tasks.json";
     let output_file_path = output_directory.join(".vscode").join(&output_file_name);
 
-    console_utils.write_info(format!(
-        "- 📄 Copying '{}' to '.vscode' directory... ",
-        output_file_name
-    ))?;
+    console_utils.write_operation_log("Copying 'tasks.json' to '.vscode' directory...", OutputEmoji::Document)?;
 
     if output_file_path.exists() {
         if !force {
@@ -197,7 +185,7 @@ pub fn copy_vscode_tasks(
 
     fs::write(&output_file_path, vscode_tasks_json)?;
 
-    console_utils.write_success(format!("Done! ✅\n"))?;
+    console_utils.write_operation_success_log()?;
 
     Ok(())
 }
@@ -215,9 +203,9 @@ pub fn ensure_tools_dir_exists(
     let vscode_dir_path = output_directory.join("tools");
 
     if !vscode_dir_path.exists() {
-        console_utils.write_info(format!("- 📁 Creating 'tools' directory... "))?;
+        console_utils.write_operation_log("Creating 'tools' directory...", OutputEmoji::Folder)?;
         std::fs::create_dir(&vscode_dir_path)?;
-        console_utils.write_success(format!("Done! ✅\n"))?;
+        console_utils.write_operation_success_log()?;
     }
 
     Ok(())
@@ -243,10 +231,7 @@ pub fn copy_build_pwsh_script(
     let output_file_name = "Build-Package.ps1";
     let output_file_path = output_directory.join("tools").join(&output_file_name);
 
-    console_utils.write_info(format!(
-        "- 📄 Copying '{}' to tools dir... ",
-        output_file_name
-    ))?;
+    console_utils.write_operation_log("Copying 'Build-Package.ps1' to tools directory... ", OutputEmoji::Document)?;
 
     if output_file_path.exists() {
         if !force {
@@ -267,7 +252,7 @@ pub fn copy_build_pwsh_script(
 
     fs::copy(template_file_path, &output_file_path)?;
 
-    console_utils.write_success(format!("Done! ✅\n"))?;
+    console_utils.write_operation_success_log()?;
 
     Ok(())
 }
@@ -292,10 +277,7 @@ pub fn copy_clean_pwsh_script(
     let output_file_name = "Clean-Package.ps1";
     let output_file_path = output_directory.join("tools").join(&output_file_name);
 
-    console_utils.write_info(format!(
-        "- 📄 Copying '{}' to tools dir... ",
-        output_file_name
-    ))?;
+    console_utils.write_operation_log("Copying 'Clean-Package.ps1' to tools directory... ", OutputEmoji::Document)?;
 
     if output_file_path.exists() {
         if !force {
@@ -316,7 +298,7 @@ pub fn copy_clean_pwsh_script(
 
     fs::copy(template_file_path, &output_file_path)?;
 
-    console_utils.write_success(format!("Done! ✅\n"))?;
+    console_utils.write_operation_success_log()?;
 
     Ok(())
 }

--- a/vscodeconfigurator/src/template_ops/vscode.rs
+++ b/vscodeconfigurator/src/template_ops/vscode.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::console_utils::ConsoleUtils;
+use crate::console_utils::{ConsoleUtils, OutputEmoji};
 
 /// Copies the `settings.json` file to the project root's `.vscode` directory.
 /// 
@@ -12,9 +12,9 @@ pub fn ensure_vscode_dir_exists(output_directory: &PathBuf, console_utils: &mut 
     let vscode_dir_path = output_directory.join(".vscode");
 
     if !vscode_dir_path.exists() {
-        console_utils.write_info(format!("- 📁 Creating '.vscode' directory... "))?;
+        console_utils.write_operation_log("Creating '.vscode' directory...", OutputEmoji::Folder)?;
         std::fs::create_dir(&vscode_dir_path)?;
-        console_utils.write_success(format!("Done! ✅\n"))?;
+        console_utils.write_operation_success_log()?;
     }
     
     Ok(())

--- a/vscodeconfigurator/src/vscode_ops/csharp.rs
+++ b/vscodeconfigurator/src/vscode_ops/csharp.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use serde_json::{json, Value};
 
 use crate::{
-    console_utils::ConsoleUtils,
+    console_utils::{ConsoleUtils, OutputEmoji},
     subcommands::csharp::CsharpLspOption,
     vscode_ops::{VSCodeSettingsFile, VSCodeTasksFile}
 };
@@ -20,7 +20,7 @@ pub fn update_csharp_lsp(
     csharp_lsp: CsharpLspOption,
     console_utils: &mut ConsoleUtils
 ) -> Result<(), Box<dyn std::error::Error>> {
-    console_utils.write_info(format!("- 📄 Updating C# LSP option in tasks.json... "))?;
+    console_utils.write_operation_log("Updating C# LSP option in tasks.json...", OutputEmoji::Document)?;
 
     let mut vscode_settings = VSCodeSettingsFile::new(output_directory.join(".vscode/settings.json"));
 
@@ -36,7 +36,7 @@ pub fn update_csharp_lsp(
 
     vscode_settings.write_settings()?;
 
-    console_utils.write_success(format!("Done! ✅\n"))?;
+    console_utils.write_operation_success_log()?;
 
     Ok(())
 }
@@ -59,7 +59,7 @@ pub fn add_csharp_project_to_tasks(
     is_watchable: bool,
     console_utils: &mut ConsoleUtils
 ) -> Result<(), Box<dyn std::error::Error>> {
-    console_utils.write_info(format!("- 📄 Adding C# project to tasks.json... "))?;
+    console_utils.write_operation_log("Adding C# project to tasks.json...", OutputEmoji::Document)?;
 
     let mut vscode_tasks = VSCodeTasksFile::new(output_directory.join(".vscode/tasks.json"));
 
@@ -92,7 +92,7 @@ pub fn add_csharp_project_to_tasks(
 
     vscode_tasks.write_tasks()?;
 
-    console_utils.write_success(format!("Done! ✅\n"))?;
+    console_utils.write_operation_success_log()?;
 
     Ok(())
 }

--- a/vscodeconfigurator/src/vscode_ops/rust.rs
+++ b/vscodeconfigurator/src/vscode_ops/rust.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use serde_json::json;
 
 use crate::{
-    console_utils::ConsoleUtils,
+    console_utils::{ConsoleUtils, OutputEmoji},
     vscode_ops::VSCodeTasksFile
 };
 
@@ -22,7 +22,7 @@ pub fn add_package_to_tasks(
     package_friendly_name: &str,
     console_utils: &mut ConsoleUtils
 ) -> Result<(), Box<dyn std::error::Error>> {
-    console_utils.write_info(format!("- 📄 Adding package to tasks.json... "))?;
+    console_utils.write_operation_log("Adding package to tasks.json...", OutputEmoji::Document)?;
 
     let mut vscode_tasks = VSCodeTasksFile::new(output_directory.join(".vscode/tasks.json"));
 
@@ -43,7 +43,7 @@ pub fn add_package_to_tasks(
 
     vscode_tasks.write_tasks()?;
 
-    console_utils.write_success(format!("Done! ✅\n"))?;
+    console_utils.write_operation_success_log()?;
 
     Ok(())
 }


### PR DESCRIPTION
## Description

- Removes the use of rewriting the log message with `regex`.
- Removes the `regex-lite` crate.
- Adds very specific logging functions that adds emojis to the output depending on whether or not the output is a TTY/terminal.
  - Also replaces all of the generic `write_info()` calls with their new corresponding logging functions.

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#31 :point\_left:
