### PR TITLE
Add rustfmt config

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,22 @@
+# Imports
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+imports_layout = "HorizontalVertical"
+reorder_imports = true
+
+# Modules
+reorder_modules = true
+
+# Comments
+wrap_comments = true
+comment_width = 80
+format_code_in_doc_comments = true
+
+# Functions
+fn_params_layout = "Vertical"
+
+# Structs
+reorder_impl_items = true
+
+# Misc
+trailing_comma = "Never"


### PR DESCRIPTION
## Description

- Adds a `rustfmt` config file to control how formatting is applied in the codebase.

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#33 :point\_left:
    - \#34
