### PR TITLE
Add ConfiguratorSubcommandArgs trait

### DIFF
--- a/vscodeconfigurator/src/subcommands/csharp/add.rs
+++ b/vscodeconfigurator/src/subcommands/csharp/add.rs
@@ -3,6 +3,8 @@ use std::{env, io::ErrorKind, path::PathBuf, process};
 use clap::{Args, ValueHint};
 use vscodeconfigurator_lib::{external_procs::dotnet, logging::ConsoleLogger, vscode_ops};
 
+use crate::subcommands::ConfiguratorSubcommandArgs;
+
 /// Defines the arguments for the `csharp add` command and the logic to run the
 /// command.
 #[derive(Args, Debug, PartialEq)]
@@ -40,9 +42,8 @@ pub struct AddCommandArgs {
     is_watchable: bool
 }
 
-impl AddCommandArgs {
-    /// Runs the `csharp add` command.
-    pub fn run_command(
+impl ConfiguratorSubcommandArgs for AddCommandArgs {
+    fn run_command(
         &self,
         logger: &mut ConsoleLogger
     ) -> Result<(), Box<dyn std::error::Error>> {

--- a/vscodeconfigurator/src/subcommands/csharp/init.rs
+++ b/vscodeconfigurator/src/subcommands/csharp/init.rs
@@ -9,6 +9,8 @@ use vscodeconfigurator_lib::{
     vscode_ops
 };
 
+use crate::subcommands::ConfiguratorSubcommandArgs;
+
 /// Defines the arguments for the `csharp init` command and the logic to run the
 /// command.
 #[derive(Args, Debug, PartialEq)]
@@ -65,9 +67,8 @@ pub struct InitCommandArgs {
     force: bool
 }
 
-impl InitCommandArgs {
-    /// Runs the `csharp init` command.
-    pub fn run_command(
+impl ConfiguratorSubcommandArgs for InitCommandArgs {
+    fn run_command(
         &self,
         logger: &mut ConsoleLogger
     ) -> Result<(), Box<dyn std::error::Error>> {
@@ -152,7 +153,9 @@ impl InitCommandArgs {
 
         Ok(())
     }
+}
 
+impl InitCommandArgs {
     /// Gets the default value for the `solution_name` (`--solution-name`)
     /// argument if it is not provided by the user.
     fn get_solution_name_value(&self) -> Option<String> {

--- a/vscodeconfigurator/src/subcommands/csharp/mod.rs
+++ b/vscodeconfigurator/src/subcommands/csharp/mod.rs
@@ -8,7 +8,7 @@ use vscodeconfigurator_lib::logging::ConsoleLogger;
 
 use self::{add::AddCommandArgs, init::InitCommandArgs};
 
-use super::ConfiguratorSubcommand;
+use super::{ConfiguratorSubcommand, ConfiguratorSubcommandArgs};
 
 /// Subcommands for C# projects.
 #[derive(Subcommand, Debug, PartialEq)]

--- a/vscodeconfigurator/src/subcommands/mod.rs
+++ b/vscodeconfigurator/src/subcommands/mod.rs
@@ -43,3 +43,13 @@ pub trait ConfiguratorSubcommand {
     /// * `logger` - The [`ConsoleLogger`](vscodeconfigurator_lib::logging::ConsoleLogger) to use for logging.
     fn match_subcommand(&self, logger: &mut ConsoleLogger) -> Result<(), Box<dyn std::error::Error>>;
 }
+
+/// A trait for subcommand arguments used in the VSCode Configurator CLI.
+pub trait ConfiguratorSubcommandArgs {
+    /// Runs the subcommand with the provided arguments.
+    /// 
+    /// # Arguments
+    /// 
+    /// - `logger` - The [`ConsoleLogger`](vscodeconfigurator_lib::logging::ConsoleLogger) to use for logging messages.
+    fn run_command(&self, logger: &mut ConsoleLogger) -> Result<(), Box<dyn std::error::Error>>;
+}

--- a/vscodeconfigurator/src/subcommands/rust/add.rs
+++ b/vscodeconfigurator/src/subcommands/rust/add.rs
@@ -6,6 +6,8 @@ use vscodeconfigurator_lib::{
     vscode_ops
 };
 
+use crate::subcommands::ConfiguratorSubcommandArgs;
+
 /// Defines the arguments for the `rust add` command and the logic to run the
 /// command.
 #[derive(Args, Debug, PartialEq)]
@@ -38,9 +40,8 @@ pub struct RustAddCommandArgs {
     package_friendly_name: Option<String>
 }
 
-impl RustAddCommandArgs {
-    /// Runs the `run add` command.
-    pub fn run_command(
+impl ConfiguratorSubcommandArgs for RustAddCommandArgs {
+    fn run_command(
         &self,
         logger: &mut ConsoleLogger
     ) -> Result<(), Box<dyn std::error::Error>> {

--- a/vscodeconfigurator/src/subcommands/rust/init.rs
+++ b/vscodeconfigurator/src/subcommands/rust/init.rs
@@ -7,6 +7,8 @@ use vscodeconfigurator_lib::{
     template_ops
 };
 
+use crate::subcommands::ConfiguratorSubcommandArgs;
+
 /// Defines the arguments for the `rust init` command and the logic to run the
 /// command.
 #[derive(Args, Debug, PartialEq)]
@@ -40,9 +42,8 @@ pub struct RustInitCommandArgs {
     force: bool
 }
 
-impl RustInitCommandArgs {
-    /// Runs the `run init` command.
-    pub fn run_command(
+impl ConfiguratorSubcommandArgs for RustInitCommandArgs {
+    fn run_command(
         &self,
         logger: &mut ConsoleLogger
     ) -> Result<(), Box<dyn std::error::Error>> {

--- a/vscodeconfigurator/src/subcommands/rust/mod.rs
+++ b/vscodeconfigurator/src/subcommands/rust/mod.rs
@@ -7,7 +7,7 @@ use clap::Subcommand;
 use vscodeconfigurator_lib::logging::ConsoleLogger;
 
 use self::{add::RustAddCommandArgs, init::RustInitCommandArgs};
-use crate::subcommands::ConfiguratorSubcommand;
+use crate::subcommands::{ConfiguratorSubcommand, ConfiguratorSubcommandArgs};
 
 /// Subcommands for Rust projects.
 #[derive(Subcommand, Debug, PartialEq)]


### PR DESCRIPTION
## Description

- Adds a trait named `ConfiguratorSubcommandArgs` that defines the `run_command()` function.

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#39 :point\_left:
