### PR TITLE
Flow serde_json errors upwards

### DIFF
--- a/vscodeconfigurator-lib/src/logging.rs
+++ b/vscodeconfigurator-lib/src/logging.rs
@@ -238,6 +238,19 @@ impl ConsoleLogger {
             );
         } else if source_error.is::<clap::error::Error>() {
             source_error_type = "CLI Argument Parser error";
+        } else if source_error.is::<serde_json::Error>() {
+            source_error_type = "JSON parsing error";
+
+            let source_error_downcast = source_error
+                .downcast_ref::<serde_json::Error>()
+                .unwrap();
+
+            source_error_kind = Some(match source_error_downcast.classify() {
+                serde_json::error::Category::Io => "I/O error",
+                serde_json::error::Category::Syntax => "Syntax error",
+                serde_json::error::Category::Data => "Data error",
+                serde_json::error::Category::Eof => "End of file error"
+            }.to_string());
         } else if source_error.is::<crate::error::CliError>() {
             source_error_type = "Internal error";
             source_error_kind = Some(

--- a/vscodeconfigurator-lib/src/vscode_ops/csharp.rs
+++ b/vscodeconfigurator-lib/src/vscode_ops/csharp.rs
@@ -59,7 +59,7 @@ pub fn update_csharp_lsp(
     )?;
 
     let mut vscode_settings =
-        VSCodeSettingsFile::new(output_directory.join(".vscode/settings.json"));
+        VSCodeSettingsFile::new(output_directory.join(".vscode/settings.json"))?;
 
     vscode_settings.values["dotnet.server.useOmnisharp"] = match csharp_lsp {
         CsharpLspOption::CsharpLsp => Value::Bool(false),
@@ -127,7 +127,7 @@ pub fn add_csharp_project_to_tasks(
 ) -> Result<(), Box<dyn std::error::Error>> {
     logger.write_operation_log("Adding C# project to tasks.json...", OutputEmoji::Document)?;
 
-    let mut vscode_tasks = VSCodeTasksFile::new(output_directory.join(".vscode/tasks.json"));
+    let mut vscode_tasks = VSCodeTasksFile::new(output_directory.join(".vscode/tasks.json"))?;
 
     let inputs_node = vscode_tasks.values["inputs"].as_array_mut().unwrap();
 

--- a/vscodeconfigurator-lib/src/vscode_ops/mod.rs
+++ b/vscodeconfigurator-lib/src/vscode_ops/mod.rs
@@ -20,18 +20,18 @@ impl VSCodeSettingsFile {
     /// # Arguments
     ///
     /// - `file_path` - The path to the settings file.
-    pub fn new(file_path: PathBuf) -> Self {
+    pub fn new(file_path: PathBuf) -> Result<Self, Box<dyn std::error::Error>> {
         if !file_path.exists() {
             panic!("The settings file does not exist.");
         }
 
-        let settings_json = fs::read_to_string(&file_path).unwrap();
-        let settings = serde_json::from_str(&settings_json.as_str()).unwrap();
+        let settings_json = fs::read_to_string(&file_path)?;
+        let settings = serde_json::from_str(&settings_json.as_str())?;
 
-        Self {
+        Ok(Self {
             file_path: file_path,
             values: settings
-        }
+        })
     }
 
     /// Writes the settings to the settings file.
@@ -59,18 +59,18 @@ impl VSCodeTasksFile {
     /// # Arguments
     ///
     /// - `file_path` - The path to the tasks file.
-    pub fn new(file_path: PathBuf) -> Self {
+    pub fn new(file_path: PathBuf) -> Result<Self, Box<dyn std::error::Error>> {
         if !file_path.exists() {
             panic!("The tasks file does not exist.");
         }
 
-        let tasks_json = fs::read_to_string(&file_path).unwrap();
-        let tasks = serde_json::from_str(&tasks_json.as_str()).unwrap();
+        let tasks_json = fs::read_to_string(&file_path)?;
+        let tasks = serde_json::from_str(&tasks_json.as_str())?;
 
-        Self {
+        Ok(Self {
             file_path: file_path,
             values: tasks
-        }
+        })
     }
 
     /// Writes the tasks to the tasks file.

--- a/vscodeconfigurator-lib/src/vscode_ops/rust.rs
+++ b/vscodeconfigurator-lib/src/vscode_ops/rust.rs
@@ -47,7 +47,7 @@ pub fn add_package_to_tasks(
 ) -> Result<(), Box<dyn std::error::Error>> {
     logger.write_operation_log("Adding package to tasks.json...", OutputEmoji::Document)?;
 
-    let mut vscode_tasks = VSCodeTasksFile::new(output_directory.join(".vscode/tasks.json"));
+    let mut vscode_tasks = VSCodeTasksFile::new(output_directory.join(".vscode/tasks.json"))?;
 
     let inputs_node = vscode_tasks.values["inputs"].as_array_mut().unwrap();
 


### PR DESCRIPTION
## Description

- Instead of terminating with a panic, `serde_json` deserialization errors will flow upwards and be properly logged.

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#40 :point\_left:
    - \#41
