### PR TITLE
Fix the name of the file in the log when updating C# LSP

### DIFF
--- a/vscodeconfigurator-lib/src/vscode_ops/csharp.rs
+++ b/vscodeconfigurator-lib/src/vscode_ops/csharp.rs
@@ -54,7 +54,7 @@ pub fn update_csharp_lsp(
     logger: &mut ConsoleLogger
 ) -> Result<(), Box<dyn std::error::Error>> {
     logger.write_operation_log(
-        "Updating C# LSP option in tasks.json...",
+        "Updating C# LSP option in settings.json...",
         OutputEmoji::Document
     )?;
 


### PR DESCRIPTION
## Description

- The file being updated to change the LSP used for C# is not `tasks.json`, but rather `settings.json`.

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#43 :point\_left:
