### PR TITLE
Set up Rust to use the nightly toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,5 +29,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+
       - name: Build project
         run: cargo build --package ${{ matrix.package_name }} --verbose

--- a/.github/workflows/configurator_create-artifacts.yml
+++ b/.github/workflows/configurator_create-artifacts.yml
@@ -26,6 +26,11 @@ jobs:
             with:
               fetch-depth: 0
 
+          - name: Setup Rust
+            uses: actions-rust-lang/setup-rust-toolchain@v1
+            with:
+              toolchain: nightly
+
           # Install targets for Rust
           - name: Install targets (Windows)
             if: ${{ runner.os == 'Windows' }}


### PR DESCRIPTION
## Description

- Set up Rust to use the nightly toolchain in CI/CD workflows.

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#44 :point\_left:
