### PR TITLE
Change binary name to 'vscode-configurator'

### DIFF
--- a/Install-VSCodeConfigurator.ps1
+++ b/Install-VSCodeConfigurator.ps1
@@ -8,7 +8,7 @@ param(
     [string]$Configuration = "Release"
 )
 
-$artifactPath = Join-Path -Path $PSScriptRoot -ChildPath "target/$($Configuration.ToLower())/vscodeconfigurator"
+$artifactPath = Join-Path -Path $PSScriptRoot -ChildPath "target/$($Configuration.ToLower())/vscode-configurator"
 $templatesArtifactPath = Join-Path -Path $PSScriptRoot -ChildPath "target/$($Configuration.ToLower())/templates"
 $installPath = Join-Path -Path ([System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::UserProfile)) -ChildPath ".vscodeconfigurator/bin/"
 

--- a/tools/Compile-VSCodeConfigurator.ps1
+++ b/tools/Compile-VSCodeConfigurator.ps1
@@ -88,12 +88,12 @@ $compiledOutputPath = Join-Path -Path $resolvedRootDirectory -ChildPath "target/
 $compiledTemplatesDirectoryPath = Join-Path -Path $compiledOutputPath -ChildPath "templates"
 $compiledBinaryPath = switch ($selectedCompilationTarget.Platform) {
     "Windows" {
-        Join-Path -Path $compiledOutputPath -ChildPath "vscodeconfigurator.exe"
+        Join-Path -Path $compiledOutputPath -ChildPath "vscode-configurator.exe"
         break
     }
 
     Default {
-        Join-Path -Path $compiledOutputPath -ChildPath "vscodeconfigurator"
+        Join-Path -Path $compiledOutputPath -ChildPath "vscode-configurator"
         break
     }
 }

--- a/vscodeconfigurator/Cargo.toml
+++ b/vscodeconfigurator/Cargo.toml
@@ -16,6 +16,10 @@ include = [
 
 build = "build.rs"
 
+[[bin]]
+name = "vscode-configurator"
+path = "src/main.rs"
+
 [dependencies]
 clap = { version = "4.5.20", features = ["derive", "string", "cargo"] }
 clap_complete = "4.5.33"

--- a/vscodeconfigurator/src/main.rs
+++ b/vscodeconfigurator/src/main.rs
@@ -15,7 +15,7 @@ use crate::subcommands::{ConfiguratorSubcommand, RootSubcommands};
 #[derive(Parser, Debug, PartialEq)]
 #[command(
     name = "VSCode Configurator",
-    bin_name = "vscodeconfigurator",
+    bin_name = "vscode-configurator",
     version = crate_version!(),
     about = "Quickly bootstrap and manage projects for VSCode.",
     long_about = None,
@@ -37,7 +37,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             generate(
                 command.shell,
                 &mut Cli::command(),
-                "vscodeconfigurator",
+                "vscode-configurator",
                 &mut std::io::stdout()
             );
             Ok(())


### PR DESCRIPTION
## Description

- Renames the binary from `vscodeconfigurator` to `vscode-configurator`.

This is to resemble the original C# version's binary name.

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#45 :point\_left:
