### PR TITLE
Add rust-toolchain.toml file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,11 @@
+[toolchain]
+channel = "nightly"
+profile = "minimal"
+components = [ "rustfmt", "clippy" ]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-gnu"
+]


### PR DESCRIPTION
## Description

- Adds a `rust-toolchain.toml` file in the project root for defining the components needed for `rustup`

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#47 :point\_left:
