### PR TITLE
[Rust template] Add rustfmt template file

### DIFF
--- a/vscodeconfigurator-lib/src/template_ops/rust.rs
+++ b/vscodeconfigurator-lib/src/template_ops/rust.rs
@@ -198,6 +198,76 @@ pub fn copy_cargo_makefile(
     Ok(())
 }
 
+/// Copies the `rustfmt.toml` file to the project root.
+///
+/// # Arguments
+///
+/// - `output_directory` - The output directory of the project.
+/// - `force` - Whether to forcefully overwrite.
+/// - `logger` - The [`ConsoleLogger`](crate::logging::ConsoleLogger) instance
+///
+/// # Examples
+///
+/// ## Example 01
+///
+/// Copies the `Makefile.toml` file to the project root with the package name
+/// `my_package`.
+///
+/// ```rust
+/// use vscodeconfigurator_lib::logging::ConsoleLogger;
+/// use vscodeconfigurator_lib::template_ops::rust::copy_rustfmt;
+///
+/// let output_directory = std::env::temp_dir().join("my-project");
+/// let package_name = "my_package";
+/// let force = false;
+/// let logger = &mut ConsoleLogger::new(None, None);
+/// 
+/// std::fs::create_dir(&output_directory).expect("Failed to create temp dir");
+///
+/// copy_rustfmt(&output_directory, force, logger);
+///
+/// std::fs::remove_dir_all(&output_directory).expect("Failed to remove temp dir");
+/// ```
+pub fn copy_rustfmt(
+    output_directory: &PathBuf,
+    force: bool,
+    logger: &mut ConsoleLogger,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let template_file = TemplateFile::new(
+        "rust/Cargo/rustfmt.toml",
+        output_directory,
+        "rustfmt.toml",
+    );
+
+    logger.write_operation_log(
+        format!(
+            "Copying '{}' to project root...",
+            &template_file.output_file_name
+        )
+        .as_str(),
+        OutputEmoji::Document,
+    )?;
+
+    if template_file.output_file_exists {
+        if !force {
+            let overwrite_response = logger.ask_for_overwrite()?;
+
+            if !overwrite_response {
+                logger.write_warning(format!("Already exists 🟠\n"))?;
+                return Ok(());
+            }
+        }
+
+        fs::remove_file(&template_file.output_file_path)?;
+    }
+
+    template_file.copy_file()?;
+
+    logger.write_operation_success_log()?;
+
+    Ok(())
+}
+
 /// Copies the `settings.json` file to the project root's `.vscode` directory.
 ///
 /// # Arguments

--- a/vscodeconfigurator/src/subcommands/rust/init.rs
+++ b/vscodeconfigurator/src/subcommands/rust/init.rs
@@ -84,6 +84,11 @@ impl ConfiguratorSubcommandArgs for RustInitCommandArgs {
             self.force,
             logger
         )?;
+        template_ops::rust::copy_rustfmt(
+            &output_directory_absolute,
+            self.force,
+            logger
+        )?;
         cargo::initalize_package(
             &output_directory_absolute,
             &self.base_package_name,

--- a/vscodeconfigurator/src/templates/rust/Cargo/rustfmt.toml
+++ b/vscodeconfigurator/src/templates/rust/Cargo/rustfmt.toml
@@ -1,0 +1,23 @@
+# Imports
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+imports_layout = "HorizontalVertical"
+reorder_imports = true
+
+# Modules
+reorder_modules = true
+
+# Comments
+wrap_comments = true
+comment_width = 80
+format_code_in_doc_comments = true
+
+# Functions
+fn_params_layout = "Vertical"
+
+# Structs
+reorder_impl_items = true
+
+# Misc
+match_block_trailing_comma = false
+trailing_comma = "Never"


### PR DESCRIPTION
## Description

Adds a `rustfmt.toml` template file for Rust.

### Related issues

- None

### Stack

<!-- branch-stack -->
