### PR TITLE
[Rust template] Add editorconfig template

### DIFF
--- a/vscodeconfigurator-lib/src/template_ops/rust.rs
+++ b/vscodeconfigurator-lib/src/template_ops/rust.rs
@@ -61,6 +61,75 @@ pub fn copy_gitignore(
     Ok(())
 }
 
+/// Copies the `.editorconfig` file to the project root.
+///
+/// # Arguments
+///
+/// - `output_directory` - The output directory of the project.
+/// - `force` - Whether to forcefully overwrite.
+/// - `logger` - The [`ConsoleLogger`](crate::logging::ConsoleLogger) instance
+///
+/// # Examples
+///
+/// ## Example 01
+///
+/// Copies the `.editorconfig` to the project root.
+///
+/// ```rust
+/// use vscodeconfigurator_lib::logging::ConsoleLogger;
+/// use vscodeconfigurator_lib::template_ops::rust::copy_editorconfig;
+///
+/// let output_directory = std::env::temp_dir().join("my-project");
+/// let package_name = "my_package";
+/// let force = false;
+/// let logger = &mut ConsoleLogger::new(None, None);
+/// 
+/// std::fs::create_dir(&output_directory).expect("Failed to create temp dir");
+///
+/// copy_editorconfig(&output_directory, force, logger);
+///
+/// std::fs::remove_dir_all(&output_directory).expect("Failed to remove temp dir");
+/// ```
+pub fn copy_editorconfig(
+    output_directory: &PathBuf,
+    force: bool,
+    logger: &mut ConsoleLogger,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let template_file = TemplateFile::new(
+        "rust/.editorconfig.template",
+        output_directory,
+        ".editorconfig",
+    );
+
+    logger.write_operation_log(
+        format!(
+            "Copying '{}' to project root...",
+            &template_file.output_file_name
+        )
+        .as_str(),
+        OutputEmoji::Document,
+    )?;
+
+    if template_file.output_file_exists {
+        if !force {
+            let overwrite_response = logger.ask_for_overwrite()?;
+
+            if !overwrite_response {
+                logger.write_warning(format!("Already exists 🟠\n"))?;
+                return Ok(());
+            }
+        }
+
+        fs::remove_file(&template_file.output_file_path)?;
+    }
+
+    template_file.copy_file()?;
+
+    logger.write_operation_success_log()?;
+
+    Ok(())
+}
+
 /// Copies the `Cargo.toml` workspace file to the project root.
 ///
 /// # Arguments

--- a/vscodeconfigurator/src/subcommands/rust/init.rs
+++ b/vscodeconfigurator/src/subcommands/rust/init.rs
@@ -57,6 +57,14 @@ impl ConfiguratorSubcommandArgs for RustInitCommandArgs {
 
         let output_directory_absolute = output_directory.to_absolute();
 
+        logger.write_operation_category("Basic")?;
+        template_ops::rust::copy_editorconfig(
+            &output_directory_absolute,
+            self.force,
+            logger
+        )?;
+        logger.write_newline()?;
+
         logger.write_operation_category("Git")?;
         git::initialize_git_repo(&output_directory_absolute, logger)?;
         template_ops::rust::copy_gitignore(&output_directory_absolute, self.force, logger)?;

--- a/vscodeconfigurator/src/templates/rust/.editorconfig.template
+++ b/vscodeconfigurator/src/templates/rust/.editorconfig.template
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8


### PR DESCRIPTION
## Description

Adds an `.editorconfig` template for Rust.

### Related issues

- None

### Stack

<!-- branch-stack -->
