### PR TITLE
[Rust template] Add Rust 2024 package edition

### DIFF
--- a/vscodeconfigurator/src/templates/rust/Cargo/Cargo.workspace.toml
+++ b/vscodeconfigurator/src/templates/rust/Cargo/Cargo.workspace.toml
@@ -3,5 +3,6 @@ members = []
 resolver = "2"
 
 package.authors = []
+package.edition = "2024"
 package.homepage = ""
 package.repository = ""


### PR DESCRIPTION
## Description

Explicitly add the 2024 Rust edition to the `Cargo.toml` file for the Rust template.

### Related issues

- None

### Stack

<!-- branch-stack -->
