### PR TITLE
Bump Rust edition to Rust 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ resolver = "2"
 package.authors = [
     "Tim Small"
 ]
+package.edition = "2024"
 package.license-file = "LICENSE"
 package.homepage = "https://github.com/Smalls1652/vscodeconfigurator-rs"
 package.repository = "https://github.com/Smalls1652/vscodeconfigurator-rs"

--- a/vscodeconfigurator-lib/Cargo.toml
+++ b/vscodeconfigurator-lib/Cargo.toml
@@ -2,9 +2,9 @@
 name = "vscodeconfigurator-lib"
 description = "Library for vscodeconfigurator."
 version = "2.0.0"
-edition = "2021"
 
 authors.workspace = true
+edition.workspace = true
 license-file.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/vscodeconfigurator/Cargo.toml
+++ b/vscodeconfigurator/Cargo.toml
@@ -2,9 +2,9 @@
 name = "vscodeconfigurator"
 description = "Quickly bootstrap and manage projects for VSCode."
 version = "2.0.0"
-edition = "2021"
 
 authors.workspace = true
+edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license-file.workspace = true

--- a/vscodeconfigurator/src/subcommands/rust/add.rs
+++ b/vscodeconfigurator/src/subcommands/rust/add.rs
@@ -62,7 +62,7 @@ impl ConfiguratorSubcommandArgs for RustAddCommandArgs {
         let output_directory_absolute = output_directory.to_absolute();
 
         let package_friendly_name = match &self.package_friendly_name {
-            Some(ref name) => &name.as_str(),
+            Some(name) => &name.as_str(),
             None => self.package_name.as_str()
         };
 


### PR DESCRIPTION
## Description

Bumps the Rust edition to 2024.

### Related issues

- None

### Stack

<!-- branch-stack -->
