### PR TITLE
[Rust template] Remove edition parameter for cargo

### DIFF
--- a/vscodeconfigurator-lib/src/external_procs/cargo.rs
+++ b/vscodeconfigurator-lib/src/external_procs/cargo.rs
@@ -79,8 +79,6 @@ pub fn initalize_package(
     let cargo_proc_args = vec![
         "init",
         package_template_arg_str,
-        "--edition",
-        "2021",
         &package_output_directory_string.as_str(),
     ];
 


### PR DESCRIPTION
## Description

Removes the usage of the `--edition` parameter when running `cargo init`, since it's defined at the workspace level (#94).

### Related issues

- None

### Stack

<!-- branch-stack -->
